### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Adds upload and download progress events to transfers.
     $progress = new Progress($uploadCallback, $downloadCallback);
 
     $client = new Client();
-    $client->get('http://httpbin.org/put', [
+    $client->put('http://httpbin.org/put', [
         'body'        => str_repeat('.', 10000),
         'subscribers' => [$progress],
     ]);


### PR DESCRIPTION
In the example code block, replace `$client->get()` by `$client->put()`
The GET request returns HTTP error: `405 METHOD NOT ALLOWED` on http://httpbin.org/put
