### PR TITLE
Minor readme tweak

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ composer.json:
 
     {
         "require": {
-            "guzzlehttp/progress-subscriber": "~1.1"
+            "guzzlehttp/progress-subscriber": "~1.0"
         }
     }
 


### PR DESCRIPTION
That number doesn't technically need to be raised. I propose we leave it at 0 to be the same as the other repos with 1.x releases or greater.
